### PR TITLE
Sys 1115/index libguides

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,8 @@ name = "pypi"
 
 [packages]
 beautifulsoup4 = "*"
+elasticsearch = "*"
 html5lib = "*"
+
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,10 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+beautifulsoup4 = "*"
+html5lib = "*"
+
+[dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0008d3e8ac6071f34f3c7f876cbe0279d9d94764c141aa8f3f72739806d3f034"
+            "sha256": "cda244b391cea5f53e193b4a55e0384ff8073a570022391609e229f05025627f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -21,6 +21,28 @@
             ],
             "index": "pypi",
             "version": "==4.11.1"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
+            ],
+            "version": "==2022.12.7"
+        },
+        "elastic-transport": {
+            "hashes": [
+                "sha256:19db271ab79c9f70f8c43f8f5b5111408781a6176b54ab2e54d713b6d9ceb815",
+                "sha256:b9ad708ceb7fcdbc6b30a96f886609a109f042c0b9d9f2e44403b3133ba7ff10"
+            ],
+            "version": "==8.4.0"
+        },
+        "elasticsearch": {
+            "hashes": [
+                "sha256:4b71ad05b36243c3b13f1c89b3ede4357011eece68917e293c43d4177d565838",
+                "sha256:f09adbea8caa633ff79e8fe115fb1d2b635426fe1a23e7e8e3bd7cce5ac3eb70"
+            ],
+            "index": "pypi",
+            "version": "==8.5.3"
         },
         "html5lib": {
             "hashes": [
@@ -43,6 +65,13 @@
                 "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"
             ],
             "version": "==2.3.2.post1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
+                "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"
+            ],
+            "version": "==1.26.13"
         },
         "webencodings": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,56 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "0008d3e8ac6071f34f3c7f876cbe0279d9d94764c141aa8f3f72739806d3f034"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30",
+                "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"
+            ],
+            "index": "pypi",
+            "version": "==4.11.1"
+        },
+        "html5lib": {
+            "hashes": [
+                "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d",
+                "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"
+            ],
+            "index": "pypi",
+            "version": "==1.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "version": "==1.16.0"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759",
+                "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"
+            ],
+            "version": "==2.3.2.post1"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# libguides-indexing-scripts
+# Libguides Indexing Scripts
+
 A collection of scripts related to harvesting and indexing LibGuides content at the UCLA Library
 
 To confirm script is able to push Libguide content to an Elasticsearch instance:
 
-Use [libguider harvester](https://github.com/tulibraries/libguider) to harvest a local copy of the libguides to index
+- Use [libguider harvester](https://github.com/tulibraries/libguider) to harvest a local copy of the libguides to index
 
-Create a local Elasticsearch instance to connect to, a local Docker Elasticsearch cluster may be created with:
+- Create a local Elasticsearch instance to connect to. A local Docker Elasticsearch cluster may be created with:
 `docker run --rm -p 9200:9200 -p 9300:9300 -e "xpack.security.enabled=false" -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:8.5.3`
 
-`python test_elastic_client.py` will iterate through the downloaded libguides, push extracted content to the default index of the local Elasticsearch cluster and print the title of each libguide
+- `python test_elastic_client.py` will iterate through the downloaded libguides, push extracted content to the default index of the local Elasticsearch cluster and print the title of each libguide

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # libguides-indexing-scripts
 A collection of scripts related to harvesting and indexing LibGuides content at the UCLA Library
+
+To confirm script is able to push Libguide content to an Elasticsearch instance:
+
+Use [libguider harvester](https://github.com/tulibraries/libguider) to harvest a local copy of the libguides to index
+
+Create a local Elasticsearch instance to connect to, a local Docker Elasticsearch cluster may be created with:
+`docker run --rm -p 9200:9200 -p 9300:9300 -e "xpack.security.enabled=false" -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:8.5.3`
+
+`python test_elastic_client.py` will iterate through the downloaded libguides, push extracted content to the default index of the local Elasticsearch cluster and print the title of each libguide

--- a/elastic_lib_client.py
+++ b/elastic_lib_client.py
@@ -1,0 +1,100 @@
+from elasticsearch import Elasticsearch
+import json
+import re
+import traceback
+from bs4 import BeautifulSoup
+from pathlib import Path
+from typing import Any
+
+
+class ElasticLibClient:
+    def __init__(
+        self,
+        base_url: str,
+        index_name: str = "index",
+        api_val: str = "",
+        user_id: str = "",
+    ) -> None:
+        self.INDEX = index_name
+        self.ELASTIC_SEARCH = Elasticsearch(base_url, api_key=(user_id, api_val))
+
+    def send_libguide(self, libguide: dict):
+        libguide["text"] = " ".join(libguide["text"])
+
+        es_doc_json = self._create_es_document(libguide)
+
+        op = self.ELASTIC_SEARCH.index(index=self.INDEX, document=es_doc_json)
+
+    def _create_es_document(self, document_data: dict):
+        """Convenience function to convert dict to Elasticsearch friendly document
+
+        Any default or common fields to all Elasticsearch docs can be added here.
+        """
+        document_data["section"] = "Libguide"
+
+        return json.dumps(document_data)
+
+    def index_libguides(self):
+        HTML_ROOT = "../libguider/data"
+        pages = "**/page*.html"
+
+        p = Path(HTML_ROOT)
+        for html_file in sorted(p.glob(pages)):
+            with open(html_file) as f:
+                # html5lib gives better results than built-in html.parser
+                soup = BeautifulSoup(f, "html5lib")
+                data = self.get_data(soup)
+
+                if data:
+                    self.send_libguide(data)
+
+                else:
+                    # TODO: Log this?
+                    guide_url = self.get_guide_url_from_path(html_file)
+                    print(f"No usable content in {html_file}: see {guide_url}")
+
+    def get_data(self, soup: BeautifulSoup) -> dict[str, Any]:
+        """Return selected data from a LibGuide HTML document.
+
+        If document does not have the wanted metadata, returns an empty dictionary.
+        """
+        data: dict = {}
+        try:
+            data["title"] = soup.find(name="meta", attrs={"name": "DC.Title"})[
+                "content"
+            ]
+            data["creator"] = soup.find(name="meta", attrs={"name": "DC.Creator"})[
+                "content"
+            ]
+            data["description"] = soup.find(
+                name="meta", attrs={"name": "DC.Description"}
+            )["content"]
+            data["url"] = soup.find(name="meta", attrs={"name": "DC.Identifier"})[
+                "content"
+            ]
+            data["text"] = [str for str in soup.body.stripped_strings]
+        except TypeError:
+            # Ignore these: HTML does not have content we want to index
+            pass
+        except Exception:
+            # Unknown other errors; for now, print stack trace and crash.
+            traceback.print_exc()
+            raise
+        return data
+
+    def get_guide_url_from_path(self, path: Path) -> str:
+        """Convert path from harvested LibGuide to a URL.
+
+        Example path: ../libguider/data/1221796/page-8937658.html
+        Matching URL: https://guides.library.ucla.edu/c.php?g=1221796&p=8937658
+        """
+        # Look for 2 groups of digits, separated by "/page-"
+        pattern = re.compile("([0-9]+)/page-([0-9]+)")
+        match = re.search(pattern, str(path))
+        if match and (len(match.groups()) == 2):
+            m1 = match.group(1)
+            m2 = match.group(2)
+            return f"https://guides.library.ucla.edu/c.php?g={m1}&p={m2}"
+        else:
+            return None
+

--- a/elastic_lib_client.py
+++ b/elastic_lib_client.py
@@ -23,7 +23,7 @@ class ElasticLibClient:
 
         es_doc_json = self._create_es_document(libguide)
 
-        op = self.ELASTIC_SEARCH.index(index=self.INDEX, document=es_doc_json)
+        self.ELASTIC_SEARCH.index(index=self.INDEX, document=es_doc_json)
 
     def _create_es_document(self, document_data: dict):
         """Convenience function to convert dict to Elasticsearch friendly document

--- a/elastic_lib_client.py
+++ b/elastic_lib_client.py
@@ -97,4 +97,3 @@ class ElasticLibClient:
             return f"https://guides.library.ucla.edu/c.php?g={m1}&p={m2}"
         else:
             return None
-

--- a/test_elastic_client.py
+++ b/test_elastic_client.py
@@ -1,0 +1,13 @@
+from elastic_lib_client import ElasticLibClient
+
+
+def main():
+    es = ElasticLibClient("http://localhost:9200")
+    es.index_libguides()
+    resp = es.ELASTIC_SEARCH.search(query={"match_all": {}})
+    for hit in resp["hits"]["hits"]:
+        print(hit["_source"]["title"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This needs work, but is in a state where an existing libguide can be read, parsed and put into an existing Elasticsearch instance, so i'm marking as draft PR for comments and improvements before merging.

To confirm:

- Downloaded libguides must be in a parallel directory to the repo, the directory that contains libguides-indexing-scripts repo, should also contain the libguider repo
- A simple test script is included that connects to a local non-secure Elasticsearch cluster. The README contains instructions on a one line docker command to spin this up if don't have locally
- `python test_elastic_client.py` will create an instance of the ElasticLibClient, extract the content, add a document to the ES cluster, and print out the title of each document, confirming the document exists in the index

Areas for improvement:

- Integration of libguider and credentials
- Elasticsearch field names will all most likely need to be changed after reviewing the existing schema, and may require some additional contortions to fit existing structures (nested documents, etc...)
- Error handling and helpful logging for edge cases
- Before indexing, drop of existing documents that match the appropriate category field value (ie section:libguides)