### PR TITLE
SYS-1125:/Update fields to match target index

### DIFF
--- a/test_elastic_client.py
+++ b/test_elastic_client.py
@@ -4,7 +4,12 @@ from elastic_lib_client import ElasticLibClient
 def main():
     es = ElasticLibClient("http://localhost:9200")
     es.index_libguides()
+    # For testing, since indexing can still be running when search is done
+    es.ELASTIC_SEARCH.indices.refresh()
+    document_count = es.ELASTIC_SEARCH.count()["count"]
+    print(f"{document_count = }")
     resp = es.ELASTIC_SEARCH.search(query={"match_all": {}})
+    print("Showing first (up to) 10 titles...")
     for hit in resp["hits"]["hits"]:
         print(hit["_source"]["title"])
 


### PR DESCRIPTION
Implements [SYS-1125](https://jira.library.ucla.edu/browse/SYS-1125).

This renames initial field names as needed to match the target ElasticSearch index:
Old | New
--- | ---
creator | _removed, for now_
description | summary
text | fullText
url | uri

It also makes a few changes to how the indexing is done and to the example/test script:
* Documents use the `uri` as the unique `id`, so documents can be re-indexed without restarting the local ES container to drop the index
* Filenames are printed to screen as indexed for clearer progress indicator
* A small number of documents is indexed by default, instead of the full set (later TODO: pass filespec for indexing to the client)
* The test program forces an index refresh, so search results are accurate immediately after indexing
* The test program shows the number of documents in the index
* The test program notes that (up to) 10 document titles are shown, after doing a `match_all` search 
