### PR TITLE
Sys 1124/api authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Keys and secrets
+api_keys.py
+*credentials*
+*secret*
+*password*

--- a/Pipfile
+++ b/Pipfile
@@ -5,8 +5,7 @@ name = "pypi"
 
 [packages]
 beautifulsoup4 = "*"
-elasticsearch = "*"
+elasticsearch = "~=7.17"
 html5lib = "*"
-
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cda244b391cea5f53e193b4a55e0384ff8073a570022391609e229f05025627f"
+            "sha256": "8023cd03b161fe3e1d563fc4b3aa3a4b3c9e377000f703f90629eb10119b0658"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -27,22 +27,16 @@
                 "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
                 "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==2022.12.7"
-        },
-        "elastic-transport": {
-            "hashes": [
-                "sha256:19db271ab79c9f70f8c43f8f5b5111408781a6176b54ab2e54d713b6d9ceb815",
-                "sha256:b9ad708ceb7fcdbc6b30a96f886609a109f042c0b9d9f2e44403b3133ba7ff10"
-            ],
-            "version": "==8.4.0"
         },
         "elasticsearch": {
             "hashes": [
-                "sha256:4b71ad05b36243c3b13f1c89b3ede4357011eece68917e293c43d4177d565838",
-                "sha256:f09adbea8caa633ff79e8fe115fb1d2b635426fe1a23e7e8e3bd7cce5ac3eb70"
+                "sha256:840adeb45a5ec9102a83f3cf481aae83a3775b75d6dd83a7310b04e44a5d0308",
+                "sha256:f511ea92e96db09b0e96b0de5fbbb7aa5c3740b0c571a364a2c3a1cc7ec06203"
             ],
             "index": "pypi",
-            "version": "==8.5.3"
+            "version": "==7.17.8"
         },
         "html5lib": {
             "hashes": [
@@ -57,6 +51,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "soupsieve": {
@@ -64,14 +59,16 @@
                 "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759",
                 "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==2.3.2.post1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
-                "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
-            "version": "==1.26.13"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.14"
         },
         "webencodings": {
             "hashes": [

--- a/elastic_lib_client.py
+++ b/elastic_lib_client.py
@@ -9,14 +9,10 @@ from typing import Any
 
 class ElasticLibClient:
     def __init__(
-        self,
-        base_url: str,
-        index_name: str = "index",
-        api_val: str = "",
-        user_id: str = "",
+        self, base_url: str, index_name: str = "index", base64_api_key: str = ""
     ) -> None:
         self.INDEX = index_name
-        self.ELASTIC_SEARCH = Elasticsearch(base_url, api_key=(user_id, api_val))
+        self.ELASTIC_SEARCH = Elasticsearch(base_url, api_key=base64_api_key)
 
     def send_libguide(self, libguide: dict):
         es_doc_json = self._create_es_document(libguide)

--- a/test_elastic_client.py
+++ b/test_elastic_client.py
@@ -1,13 +1,38 @@
 from elastic_lib_client import ElasticLibClient
+import argparse
+import api_keys
 
 
 def main():
-    es = ElasticLibClient("http://localhost:9200")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i",
+        "--index",
+        help="Elasticsearch index to perform operations on",
+        action="store",
+        default="index",
+    )
+    parser.add_argument(
+        "-u",
+        "--base_url",
+        help="Base url of Elasticsearch index to use",
+        action="store",
+        default="http://localhost:9200",
+    )
+
+    args = parser.parse_args()
+
+    es = ElasticLibClient(
+        index_name=args.index, base_url=args.base_url, base64_api_key=api_keys.API_KEY
+    )
+
     es.index_libguides()
     # For testing, since indexing can still be running when search is done
     es.ELASTIC_SEARCH.indices.refresh()
     document_count = es.ELASTIC_SEARCH.count()["count"]
     print(f"{document_count = }")
+    
     resp = es.ELASTIC_SEARCH.search(query={"match_all": {}})
     print("Showing first (up to) 10 titles...")
     for hit in resp["hits"]["hits"]:


### PR DESCRIPTION
Some tweaks for review and feedback related to Elasticsearch authentication

- Command line arguments added for handling the url and index to connect to added to `test_elastic_client.py` testing script

-u, base url of the Elasticsearch server. Default value `http://localhost:9200`
-i, index name to use on this server. Default value: `index`

Example use:

Minimum: `python test_elastic_client.py`
Uses default Elasticsearch location of localhost:9200 and default index

With arguments:
`python test_elastic_client.py -u https://elastical.library.ucla.edu -i apps-stage-lib`
Connects to es instance at the url provided and uses a specific index

- API key authentication

By default ignored, to use an api key, create a file titled `api_keys.py` in the root repo directory with the format:
`API_KEY = "base64-api-key-goes-here"`

The value should be the base64 encoded string that contains both the api id and api key. The client constructor has been updated to only require this string and the authentication persists for the life of the client object.

This is the ground floor for API authorization for client and a simple test. 

Additional tickets will be created for known smaller functionality that should be added including option for deleting documents with sectionHandle value of Libguides

