### PR TITLE
SYS-1133: Provide path/filespec to be indexed instead of hard-coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of scripts related to harvesting and indexing LibGuides content at 
 
 To confirm script is able to push Libguide content to an Elasticsearch instance:
 
-- Use [libguider harvester](https://github.com/tulibraries/libguider) to harvest a local copy of the libguides to index
+- Use [libguider harvester](https://github.com/UCLALibrary/libguider) to harvest a local copy of the libguides to index
 
 - Create a local Elasticsearch instance to connect to. A local Docker Elasticsearch cluster may be created with:
 `docker run --rm -p 9200:9200 -p 9300:9300 -e "xpack.security.enabled=false" -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:8.5.3`

--- a/elastic_lib_client.py
+++ b/elastic_lib_client.py
@@ -31,15 +31,19 @@ class ElasticLibClient:
         document_data.pop("creator", None)
         return json.dumps(document_data)
 
-    def index_libguides(self):
-        # TODO: Pass path/filespec into this instead of hard-coding.
-        HTML_ROOT = "../libguider/data"
-        pages = "**/page*.html"
-        # 4 pages, for small tests
-        pages = "710903/page*.html"
+    def index_libguides(
+        self, html_root: str = "../libguider/data", file_spec: str = "**/page*.html"
+    ):
+        """Index HTML LibGuides previously downloaded (via libguider).
 
-        p = Path(HTML_ROOT)
-        for html_file in sorted(p.glob(pages)):
+        Keyword arguments:
+        html_root: Relative path to the directory containing files to index.
+        file_spec: Pattern used to match files to index.
+        Defaults will index all files downloaded by
+        a parallel installation of https://github.com/UCLALibrary/libguider
+        """
+        p = Path(html_root)
+        for html_file in sorted(p.glob(file_spec)):
             print(f"Indexing {html_file}")
             with open(html_file) as f:
                 # html5lib gives better results than built-in html.parser

--- a/test_elastic_client.py
+++ b/test_elastic_client.py
@@ -27,12 +27,16 @@ def main():
         index_name=args.index, base_url=args.base_url, base64_api_key=api_keys.API_KEY
     )
 
-    es.index_libguides()
+    # 4 pages, for small tests
+    es.index_libguides(file_spec="710903/page*.html")
+    # Or do a full test indexing of all pages
+    # es.index_libguides()
+
     # For testing, since indexing can still be running when search is done
     es.ELASTIC_SEARCH.indices.refresh()
     document_count = es.ELASTIC_SEARCH.count()["count"]
     print(f"{document_count = }")
-    
+
     resp = es.ELASTIC_SEARCH.search(query={"match_all": {}})
     print("Showing first (up to) 10 titles...")
     for hit in resp["hits"]["hits"]:


### PR DESCRIPTION
Implements [SYS-1133](https://jira.library.ucla.edu/browse/SYS-1133).

This PR refactors `ElasticLibClient.index_libguides()` to accept path and filespec of files to be indexed, instead of hard-coding them.  By default, all files downloaded by `libguider` in a parallel directory (../libguider) will be indexed.

The test script `test_elastic_client.py` is updated to use a small subdirectory with 4 files to index, with a full indexing commented out.  `README.md` is updated to point to our fork of `libguider`.

Testing: Start local Elasticsearch and run `python test_elastic_client.py`
Output should show (assuming empty starting index):
```
Indexing ../libguider/data/710903/page-5057707.html
Indexing ../libguider/data/710903/page-5058338.html
Indexing ../libguider/data/710903/page-5058380.html
Indexing ../libguider/data/710903/page-7755753.html
document_count = 4
Showing first (up to) 10 titles...
Research Guides: Political Science 150: Political Violence: Home
Research Guides: Political Science 150: Political Violence: Databases for Finding Journal Articles
Research Guides: Political Science 150: Political Violence: Citing Your Sources
Research Guides: Political Science 150: Political Violence: Finding Useful Books
```