### PR TITLE
SYS-1128: Add script to find website URLs not yet redirected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,9 @@ api_keys.py
 *credentials*
 *secret*
 *password*
+
+# Data files
+.csv
+.tsv
+.json
+.dict

--- a/Pipfile
+++ b/Pipfile
@@ -7,5 +7,6 @@ name = "pypi"
 beautifulsoup4 = "*"
 elasticsearch = "~=7.17"
 html5lib = "*"
+requests = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8023cd03b161fe3e1d563fc4b3aa3a4b3c9e377000f703f90629eb10119b0658"
+            "sha256": "22e92bc138f4c224de7b77dd30ce554270ec1a7849d2153155cdc7051411ff6e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -27,8 +27,100 @@
                 "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
                 "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==2022.12.7"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b",
+                "sha256:024e606be3ed92216e2b6952ed859d86b4cfa52cd5bc5f050e7dc28f9b43ec42",
+                "sha256:0298eafff88c99982a4cf66ba2efa1128e4ddaca0b05eec4c456bbc7db691d8d",
+                "sha256:02a51034802cbf38db3f89c66fb5d2ec57e6fe7ef2f4a44d070a593c3688667b",
+                "sha256:083c8d17153ecb403e5e1eb76a7ef4babfc2c48d58899c98fcaa04833e7a2f9a",
+                "sha256:0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59",
+                "sha256:0bf2dae5291758b6f84cf923bfaa285632816007db0330002fa1de38bfcb7154",
+                "sha256:0c0a590235ccd933d9892c627dec5bc7511ce6ad6c1011fdf5b11363022746c1",
+                "sha256:0f438ae3532723fb6ead77e7c604be7c8374094ef4ee2c5e03a3a17f1fca256c",
+                "sha256:109487860ef6a328f3eec66f2bf78b0b72400280d8f8ea05f69c51644ba6521a",
+                "sha256:11b53acf2411c3b09e6af37e4b9005cba376c872503c8f28218c7243582df45d",
+                "sha256:12db3b2c533c23ab812c2b25934f60383361f8a376ae272665f8e48b88e8e1c6",
+                "sha256:14e76c0f23218b8f46c4d87018ca2e441535aed3632ca134b10239dfb6dadd6b",
+                "sha256:16a8663d6e281208d78806dbe14ee9903715361cf81f6d4309944e4d1e59ac5b",
+                "sha256:292d5e8ba896bbfd6334b096e34bffb56161c81408d6d036a7dfa6929cff8783",
+                "sha256:2c03cc56021a4bd59be889c2b9257dae13bf55041a3372d3295416f86b295fb5",
+                "sha256:2e396d70bc4ef5325b72b593a72c8979999aa52fb8bcf03f701c1b03e1166918",
+                "sha256:2edb64ee7bf1ed524a1da60cdcd2e1f6e2b4f66ef7c077680739f1641f62f555",
+                "sha256:31a9ddf4718d10ae04d9b18801bd776693487cbb57d74cc3458a7673f6f34639",
+                "sha256:356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786",
+                "sha256:358a7c4cb8ba9b46c453b1dd8d9e431452d5249072e4f56cfda3149f6ab1405e",
+                "sha256:37f8febc8ec50c14f3ec9637505f28e58d4f66752207ea177c1d67df25da5aed",
+                "sha256:39049da0ffb96c8cbb65cbf5c5f3ca3168990adf3551bd1dee10c48fce8ae820",
+                "sha256:39cf9ed17fe3b1bc81f33c9ceb6ce67683ee7526e65fde1447c772afc54a1bb8",
+                "sha256:3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3",
+                "sha256:3b590df687e3c5ee0deef9fc8c547d81986d9a1b56073d82de008744452d6541",
+                "sha256:3e45867f1f2ab0711d60c6c71746ac53537f1684baa699f4f668d4c6f6ce8e14",
+                "sha256:3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be",
+                "sha256:4457ea6774b5611f4bed5eaa5df55f70abde42364d498c5134b7ef4c6958e20e",
+                "sha256:44ba614de5361b3e5278e1241fda3dc1838deed864b50a10d7ce92983797fa76",
+                "sha256:4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b",
+                "sha256:4b0d02d7102dd0f997580b51edc4cebcf2ab6397a7edf89f1c73b586c614272c",
+                "sha256:502218f52498a36d6bf5ea77081844017bf7982cdbe521ad85e64cabee1b608b",
+                "sha256:503e65837c71b875ecdd733877d852adbc465bd82c768a067badd953bf1bc5a3",
+                "sha256:5995f0164fa7df59db4746112fec3f49c461dd6b31b841873443bdb077c13cfc",
+                "sha256:59e5686dd847347e55dffcc191a96622f016bc0ad89105e24c14e0d6305acbc6",
+                "sha256:601f36512f9e28f029d9481bdaf8e89e5148ac5d89cffd3b05cd533eeb423b59",
+                "sha256:608862a7bf6957f2333fc54ab4399e405baad0163dc9f8d99cb236816db169d4",
+                "sha256:62595ab75873d50d57323a91dd03e6966eb79c41fa834b7a1661ed043b2d404d",
+                "sha256:70990b9c51340e4044cfc394a81f614f3f90d41397104d226f21e66de668730d",
+                "sha256:71140351489970dfe5e60fc621ada3e0f41104a5eddaca47a7acb3c1b851d6d3",
+                "sha256:72966d1b297c741541ca8cf1223ff262a6febe52481af742036a0b296e35fa5a",
+                "sha256:74292fc76c905c0ef095fe11e188a32ebd03bc38f3f3e9bcb85e4e6db177b7ea",
+                "sha256:761e8904c07ad053d285670f36dd94e1b6ab7f16ce62b9805c475b7aa1cffde6",
+                "sha256:772b87914ff1152b92a197ef4ea40efe27a378606c39446ded52c8f80f79702e",
+                "sha256:79909e27e8e4fcc9db4addea88aa63f6423ebb171db091fb4373e3312cb6d603",
+                "sha256:7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24",
+                "sha256:7eb33a30d75562222b64f569c642ff3dc6689e09adda43a082208397f016c39a",
+                "sha256:81d6741ab457d14fdedc215516665050f3822d3e56508921cc7239f8c8e66a58",
+                "sha256:8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678",
+                "sha256:84c3990934bae40ea69a82034912ffe5a62c60bbf6ec5bc9691419641d7d5c9a",
+                "sha256:87701167f2a5c930b403e9756fab1d31d4d4da52856143b609e30a1ce7160f3c",
+                "sha256:88600c72ef7587fe1708fd242b385b6ed4b8904976d5da0893e31df8b3480cb6",
+                "sha256:8ac7b6a045b814cf0c47f3623d21ebd88b3e8cf216a14790b455ea7ff0135d18",
+                "sha256:8b8af03d2e37866d023ad0ddea594edefc31e827fee64f8de5611a1dbc373174",
+                "sha256:8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317",
+                "sha256:8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f",
+                "sha256:911d8a40b2bef5b8bbae2e36a0b103f142ac53557ab421dc16ac4aafee6f53dc",
+                "sha256:93ad6d87ac18e2a90b0fe89df7c65263b9a99a0eb98f0a3d2e079f12a0735837",
+                "sha256:95dea361dd73757c6f1c0a1480ac499952c16ac83f7f5f4f84f0658a01b8ef41",
+                "sha256:9ab77acb98eba3fd2a85cd160851816bfce6871d944d885febf012713f06659c",
+                "sha256:9cb3032517f1627cc012dbc80a8ec976ae76d93ea2b5feaa9d2a5b8882597579",
+                "sha256:9cf4e8ad252f7c38dd1f676b46514f92dc0ebeb0db5552f5f403509705e24753",
+                "sha256:9d9153257a3f70d5f69edf2325357251ed20f772b12e593f3b3377b5f78e7ef8",
+                "sha256:a152f5f33d64a6be73f1d30c9cc82dfc73cec6477ec268e7c6e4c7d23c2d2291",
+                "sha256:a16418ecf1329f71df119e8a65f3aa68004a3f9383821edcb20f0702934d8087",
+                "sha256:a60332922359f920193b1d4826953c507a877b523b2395ad7bc716ddd386d866",
+                "sha256:a8d0fc946c784ff7f7c3742310cc8a57c5c6dc31631269876a88b809dbeff3d3",
+                "sha256:ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d",
+                "sha256:c22d3fe05ce11d3671297dc8973267daa0f938b93ec716e12e0f6dee81591dc1",
+                "sha256:c2ac1b08635a8cd4e0cbeaf6f5e922085908d48eb05d44c5ae9eabab148512ca",
+                "sha256:c512accbd6ff0270939b9ac214b84fb5ada5f0409c44298361b2f5e13f9aed9e",
+                "sha256:c75ffc45f25324e68ab238cb4b5c0a38cd1c3d7f1fb1f72b5541de469e2247db",
+                "sha256:c95a03c79bbe30eec3ec2b7f076074f4281526724c8685a42872974ef4d36b72",
+                "sha256:cadaeaba78750d58d3cc6ac4d1fd867da6fc73c88156b7a3212a3cd4819d679d",
+                "sha256:cd6056167405314a4dc3c173943f11249fa0f1b204f8b51ed4bde1a9cd1834dc",
+                "sha256:db72b07027db150f468fbada4d85b3b2729a3db39178abf5c543b784c1254539",
+                "sha256:df2c707231459e8a4028eabcd3cfc827befd635b3ef72eada84ab13b52e1574d",
+                "sha256:e62164b50f84e20601c1ff8eb55620d2ad25fb81b59e3cd776a1902527a788af",
+                "sha256:e696f0dd336161fca9adbb846875d40752e6eba585843c768935ba5c9960722b",
+                "sha256:eaa379fcd227ca235d04152ca6704c7cb55564116f8bc52545ff357628e10602",
+                "sha256:ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f",
+                "sha256:f4c39b0e3eac288fedc2b43055cfc2ca7a60362d0e5e87a637beac5d801ef478",
+                "sha256:f5057856d21e7586765171eac8b9fc3f7d44ef39425f85dbcccb13b3ebea806c",
+                "sha256:f6f45710b4459401609ebebdbcfb34515da4fc2aa886f95107f556ac69a9147e",
+                "sha256:f97e83fa6c25693c7a35de154681fcc257c1c41b38beb0304b9c4d2d9e164479",
+                "sha256:f9d0c5c045a3ca9bedfc35dca8526798eb91a07aa7a2c0fee134c6c6f321cbd7",
+                "sha256:ff6f3db31555657f3163b15a6b7c6938d08df7adbfc9dd13d9d19edad678f1e8"
+            ],
+            "version": "==3.0.1"
         },
         "elasticsearch": {
             "hashes": [
@@ -46,12 +138,26 @@
             "index": "pypi",
             "version": "==1.1"
         },
+        "idna": {
+            "hashes": [
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            ],
+            "version": "==3.4"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
+                "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"
+            ],
+            "index": "pypi",
+            "version": "==2.28.2"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "soupsieve": {
@@ -59,7 +165,6 @@
                 "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759",
                 "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==2.3.2.post1"
         },
         "urllib3": {
@@ -67,7 +172,6 @@
                 "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
                 "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.14"
         },
         "webencodings": {

--- a/get_website_urls.py
+++ b/get_website_urls.py
@@ -1,0 +1,197 @@
+import csv
+import re
+import requests
+import sys
+import traceback
+from bs4 import BeautifulSoup
+from pathlib import Path
+from typing import Any, List
+
+from pprint import pprint  # for debugging
+
+
+def get_guide_url_from_path(path: Path) -> str:
+    """Convert path from harvested LibGuide to a URL.
+
+    Example path: ../libguider/data/1221796/page-8937658.html
+    Matching URL: https://guides.library.ucla.edu/c.php?g=1221796&p=8937658
+    """
+    # Look for 2 groups of digits, separated by "/page-"
+    pattern = re.compile("([0-9]+)/page-([0-9]+)")
+    match = re.search(pattern, str(path))
+    if match and (len(match.groups()) == 2):
+        m1 = match.group(1)
+        m2 = match.group(2)
+        return f"https://guides.library.ucla.edu/c.php?g={m1}&p={m2}"
+    else:
+        return None
+
+
+def get_libguide_data(soup: BeautifulSoup) -> dict[str, Any]:
+    """Return selected data from a LibGuide HTML document.
+
+    If document does not have the wanted metadata, returns an empty dictionary.
+    """
+    data: dict = {}
+    try:
+        data["title"] = soup.find(name="meta", attrs={"name": "DC.Title"})["content"]
+        data["creator"] = soup.find(name="meta", attrs={"name": "DC.Creator"})[
+            "content"
+        ]
+        data["uri"] = soup.find(name="meta", attrs={"name": "DC.Identifier"})["content"]
+        # Many duplicate links in some files, so dedup via set
+        website_links = set()
+        # Act only on links we care about
+        # Find links to main website, not other related sites
+        LINKS_TO_FIND = ["//library.ucla.edu", "//www.library.ucla.edu"]
+        for link in soup.find_all("a", href=True):
+            link_to_check = link["href"]
+            for link_to_find in LINKS_TO_FIND:
+                if link_to_find in link_to_check:
+                    # Format links in a standard way
+                    website_link = standardize_link(link_to_check)
+                    website_links.add(website_link)
+                    # print(website_link)
+        data["links"] = website_links
+    except TypeError:
+        # Ignore these: HTML does not have content we want to index
+        pass
+    except Exception:
+        # Unknown other errors; for now, print stack trace and crash.
+        traceback.print_exc()
+        raise
+    return data
+
+
+def standardize_link(link: str) -> str:
+    # QAD application of standard format for deduplication
+    # Could be https://, http://, or scheme-less like // - remove all for de-duping
+    # Also strip terminal / if present.
+    # Remove internal spaces, which are typos.
+    link = link.replace(" ", "")
+    patterns_to_replace = "https://?|http://?|^//?|/$"
+    printable_link = re.sub(patterns_to_replace, "", link)
+    # Remove embedded CR/LF
+    printable_link = printable_link.replace("\r", "").replace("\n", "")
+    # Change bare library.ucla.edu to www.library.ucla.edu
+    if printable_link.startswith("library"):
+        printable_link = "www." + printable_link
+    # Finally, use consistent https scheme
+    return "https://" + printable_link
+
+
+def get_website_urls() -> dict:
+    # Dictionary of all relevant libguides data, keyed on website url.
+    # Each url will have a list of dicts of other libguides data,
+    # for each page it's used in.
+    website_urls: dict[str, List] = {}
+
+    HTML_ROOT = "../libguider/data"
+    pages = "**/page*.html"
+    # 4 pages, for small tests
+    # pages = "710903/page*.html"
+    p = Path(HTML_ROOT)
+    for html_file in sorted(p.glob(pages)):
+        print(f"Checking {html_file}...")
+        with open(html_file) as f:
+            # html5lib gives better results than built-in html.parser
+            soup = BeautifulSoup(f, "html5lib")
+            libguide_data = get_libguide_data(soup)
+            libguide_data["guide_url"] = get_guide_url_from_path(html_file)
+            libguide_data["html_file"] = str(html_file)
+
+        # Go through each page's unique library links, and
+        # add data for each unique website url to dictionary.
+        # Copy links, then delete from libguide_data - unneeded clutter.
+        links = libguide_data.get("links")
+        if links:
+            del libguide_data["links"]
+            for url in links:
+                if website_urls.get(url):
+                    website_urls[url].append(libguide_data)
+                else:
+                    website_urls[url] = [libguide_data]
+
+    return website_urls
+
+
+def get_redirect_data(redirect_filename: str) -> list:
+    redirects: list = []
+    with open(redirect_filename) as csv_file:
+        reader = csv.DictReader(csv_file)
+        for line in reader:
+            redirects.append(line)
+    # We need just the old website URL
+    return [redirect["Custom field (URL)"] for redirect in redirects]
+
+
+def write_missing_redirects(missing_redirects: list) -> None:
+    column_headers = missing_redirects[0].keys()
+    with open("missing_redirects.csv", "wt") as csv_file:
+        writer = csv.DictWriter(csv_file, column_headers, dialect="excel")
+        writer.writeheader()
+        writer.writerows(missing_redirects)
+
+    # Create summary file with urls and number of libguide pages using each
+    urls = [redirect["website_url"] for redirect in missing_redirects]
+    counts = {url: urls.count(url) for url in urls}
+    summary = [{"website_url": k, "libguide_count": v} for (k, v) in counts.items()]
+    column_headers = summary[0].keys()
+    with open("missing_redirects_summary.csv", "wt") as csv_file:
+        writer = csv.DictWriter(csv_file, column_headers, dialect="excel")
+        writer.writeheader()
+        writer.writerows(summary)
+
+
+def main() -> None:
+    redirect_filename = sys.argv[1]
+    redirects = get_redirect_data(redirect_filename)
+    website_urls = get_website_urls()
+
+    # Compare each website url from libguides with redirects
+    # and report on those which are not found.
+    print(f"Checking redirects for {len(website_urls)} libguides website urls...")
+    # Collect output data in missing_redirects
+    missing_redirects: list = []
+    for website_url in sorted(website_urls):
+        if website_url in redirects:
+            print(f"Found {website_url} - skipping")
+            found = True
+        else:
+            # Some urls are redirected within Drupal, so if first check is not found,
+            # get the final url and check it too.
+            print(f"{website_url} not found, checking Drupal redirect...")
+            found = False
+            response = requests.get(website_url, allow_redirects=True)
+            new_url = response.url
+            status_code = response.status_code
+            if new_url != website_url:
+                if new_url in redirects:
+                    print(f"Found Drupal redirect {new_url} - skipping")
+                    found = True
+                else:
+                    print(f"{new_url} Drupal redirect also not found")
+                    found = False
+            else:
+                # Clear new_url for simpler logs, since it's same as website_url
+                new_url = ""
+        if not found:
+            print(f"Reporting {website_url}")
+            libguide_pages: list = website_urls[website_url]
+            for page in libguide_pages:
+                missing_redirects.append(
+                    {
+                        "website_url": website_url,
+                        "website_alias": new_url,
+                        "status_code": status_code,
+                        "libguide_url": page["guide_url"],
+                        "creator": page["creator"],
+                        "title": page["title"],
+                    }
+                )
+        print()
+    write_missing_redirects(missing_redirects)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements [SYS-1128](https://jira.library.ucla.edu/browse/SYS-1128).

This PR adds `get_website_urls.py`, a script which
1) Pulls all URLs for the main library website from previously-harvested (via `libguider`) LibGuides HTML pages
2) Compares those with a list of already-handled redirects intended for use with the new library website
3) Reports on URLs in (1) which are not in (2)

A new external dependency, `requests`, was added to the `pipenv`.

This is probably a one-time-use script, but I'm adding it to this repository just in case.  It's already been run, it doesn't change any data, so I'm skipping review for it.  But @kjallen , FYI :)

