### PR TITLE
remove "Research Guides: " prefix from titles

### DIFF
--- a/elastic_lib_client.py
+++ b/elastic_lib_client.py
@@ -73,7 +73,7 @@ class ElasticLibClient:
         try:
             data["title"] = soup.find(name="meta", attrs={"name": "DC.Title"})[
                 "content"
-            ].removeprefix("Research Guides: ")
+            ].replace("Research Guides: ", "")
             data["creator"] = soup.find(name="meta", attrs={"name": "DC.Creator"})[
                 "content"
             ]

--- a/elastic_lib_client.py
+++ b/elastic_lib_client.py
@@ -73,7 +73,7 @@ class ElasticLibClient:
         try:
             data["title"] = soup.find(name="meta", attrs={"name": "DC.Title"})[
                 "content"
-            ]
+            ].removeprefix("Research Guides: ")
             data["creator"] = soup.find(name="meta", attrs={"name": "DC.Creator"})[
                 "content"
             ]


### PR DESCRIPTION
The prefix gets added by libguides, we are asked to remove it by [APPS-2542](https://uclalibrary.atlassian.net/browse/APPS-2542)

This requires python 3.9 for `str.removeprefix()`. If we need to use an earlier python, I can change it to `.replace()`

[APPS-2542]: https://uclalibrary.atlassian.net/browse/APPS-2542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ